### PR TITLE
Fix for resize bar position of columns

### DIFF
--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -76,7 +76,7 @@
 					var n = $('thead tr:first th:visible', g.hDiv).index(this);
 					var cdpos = parseInt($('div', this).width());
 					if (cdleft == 0) cdleft -= Math.floor(p.cgwidth / 2);
-					cdpos = cdpos + cdleft + cdpad;
+					cdpos = cdpos + cdleft + cdpad - 1;
 					if (isNaN(cdpos)) {
 						cdpos = 0;
 					}


### PR DESCRIPTION
The border for resizing columns is shifted by 1px x (column position) and is no longer positioned above.
