### PR TITLE
Use modern serialization if params option is an object

### DIFF
--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -538,28 +538,39 @@
 				if (p.page > p.pages) {
 					p.page = p.pages;
 				}
-				var param = [{
-					name: 'page',
-					value: p.newp
-				}, {
-					name: 'rp',
-					value: p.rp
-				}, {
-					name: 'sortname',
-					value: p.sortname
-				}, {
-					name: 'sortorder',
-					value: p.sortorder
-				}, {
-					name: 'query',
-					value: p.query
-				}, {
-					name: 'qtype',
-					value: p.qtype
-				}];
-				if (p.params.length) {
-					for (var pi = 0; pi < p.params.length; pi++) {
-						param[param.length] = p.params[pi];
+				var param;
+				if ($.isPlainObject(p.params)) {
+					param			= p.params;
+					param.page		= p.newp;
+					param.rp		= p.rp;
+					param.sortname	= p.sortname;
+					param.sortorder	= p.sortorder;
+					param.query		= p.query;
+					param.qtype		= p.qtype;
+				} else {
+					param = [{
+						name: 'page',
+						value: p.newp
+					}, {
+						name: 'rp',
+						value: p.rp
+					}, {
+						name: 'sortname',
+						value: p.sortname
+					}, {
+						name: 'sortorder',
+						value: p.sortorder
+					}, {
+						name: 'query',
+						value: p.query
+					}, {
+						name: 'qtype',
+						value: p.qtype
+					}];
+					if (p.params.length) {
+						for (var pi = 0; pi < p.params.length; pi++) {
+							param[param.length] = p.params[pi];
+						}
 					}
 				}
 				$.ajax({

--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -27,7 +27,7 @@
 			total: 1, //total pages
 			useRp: true, //use the results per page select box
 			rp: 15, //results per page
-			rpOptions: [10, 15, 20, 30, 50], //allowed per-page values 
+			rpOptions: [10, 15, 20, 30, 50], //allowed per-page values
 			title: false,
 			idProperty: 'id',
 			pagestat: 'Displaying {from} to {to} of {total} items',
@@ -227,8 +227,10 @@
 					this.rePosDrag();
 					this.fixHeight();
 					this.colresize = false;
-					var name = p.colModel[n].name;		// Store the widths in the cookies
-					$.cookie('flexiwidths/'+name, nw);					
+					if ($.cookie) {
+						var name = p.colModel[n].name;		// Store the widths in the cookies
+						$.cookie('flexiwidths/'+name, nw);
+					}
 				} else if (this.vresize) {
 					this.vresize = false;
 				} else if (this.colCopy) {
@@ -380,7 +382,7 @@
 								if( offs >0 ) {
 									$(td).css('background',  text.substr(offs+7,7) );
 								}
-								
+
 								$(td).attr('abbr', $(this).attr('abbr'));
 								$(tr).append(td);
 								td = null;
@@ -423,13 +425,13 @@
 							var td = document.createElement('td');
 							var idx = $(this).attr('axis').substr(3);
 							td.align = this.align;
-							
+
 							var text = $("cell:eq(" + idx + ")", robj).text();
 							var offs = text.indexOf( '<BGCOLOR=' );
 							if( offs >0 ) {
 								$(td).css('background',  text.substr(offs+7,7) );
 							}
-							td.innerHTML = text;							
+							td.innerHTML = text;
 							$(td).attr('abbr', $(this).attr('abbr'));
 							$(tr).append(td);
 							td = null;
@@ -700,8 +702,8 @@
 						}
 						if (e.ctrlKey)
 						{
-							$(this).toggleClass('trSelected'); 
-							g.multisel = true; 
+							$(this).toggleClass('trSelected');
+							g.multisel = true;
 							this.focus();
 						}
 					}).mouseup(function () {
@@ -727,7 +729,7 @@
 					}
 				});
 			},
-			
+
 			combo_flag: true,
 			combo_resetIndex: function(selObj)
 			{
@@ -741,7 +743,7 @@
 				eval( selObj.options[selObj.selectedIndex].value );
 				selObj.selectedIndex = 0;
 				this.combo_flag = false;
-			},			
+			},
 			//Add title attribute to div if cell contents is truncated
 			addTitleToCell: function(tdDiv) {
 				if(p.addTitleToCell) {
@@ -749,14 +751,14 @@
 						$div = (tdDiv instanceof jQuery) ? tdDiv : $(tdDiv),
 						div_w = $div.outerWidth(),
 						span_w = 0;
-					
+
 					$('body').children(':first').before($span);
 					$span.html($div.html());
 					$span.css('font-size', '' + $div.css('font-size'));
 					$span.css('padding-left', '' + $div.css('padding-left'));
 					span_w = $span.innerWidth();
 					$span.remove();
-					
+
 					if(span_w > div_w) {
 						$div.attr('title', $div.text());
 					} else {
@@ -811,9 +813,11 @@
 				var th = document.createElement('th');
 				$(th).attr('axis', 'col' + i);
 				if( cm ) {	// only use cm if its defined
-					var cookie_width = 'flexiwidths/'+cm.name;		// Re-Store the widths in the cookies
-					if( $.cookie(cookie_width) != undefined ) {
-						cm.width = $.cookie(cookie_width);
+					if ($.cookie) {
+						var cookie_width = 'flexiwidths/'+cm.name;		// Re-Store the widths in the cookies
+						if( $.cookie(cookie_width) != undefined ) {
+							cm.width = $.cookie(cookie_width);
+						}
 					}
 					if( cm.display != undefined ) {
 						th.innerHTML = cm.display;
@@ -891,10 +895,10 @@
 					if (btn.bimage) // if bimage defined, use its string as an image url for this buttons style (RS)
 						$('span',btnDiv).css( 'background', 'url('+btn.bimage+') no-repeat center left' );
 						$('span',btnDiv).css( 'paddingLeft', 20 );
-						
+
 					if (btn.tooltip) // add title if exists (RS)
 						$('span',btnDiv)[0].title = btn.tooltip;
-						
+
 					btnDiv.onpress = btn.onpress;
 					btnDiv.name = btn.name;
 					if (btn.id) {
@@ -922,19 +926,19 @@
 			$(g.gDiv).prepend(g.tDiv);
 		}
 		g.hDiv.className = 'hDiv';
-		
+
 		// Define a combo button set with custom action'ed calls when clicked.
 		if( p.combobuttons && $(g.tDiv2) )
 		{
 			var btnDiv = document.createElement('div');
 			btnDiv.className = 'fbutton';
-			
+
 			var tSelect = document.createElement('select');
 			$(tSelect).change( function () { g.combo_doSelectAction( tSelect ) } );
 			$(tSelect).click( function () { g.combo_resetIndex( tSelect) } );
 			tSelect.className = 'cselect';
 			$(btnDiv).append(tSelect);
-			
+
 			for (i=0;i<p.combobuttons.length;i++)
 			{
 				var btn = p.combobuttons[i];
@@ -942,8 +946,8 @@
 				{
 					var btnOpt = document.createElement('option');
 					btnOpt.innerHTML = btn.name;
-					
-					if (btn.bclass) 
+
+					if (btn.bclass)
 						$(btnOpt)
 						.addClass(btn.bclass)
 						.css({paddingLeft:20})
@@ -951,21 +955,21 @@
 					if (btn.bimage)  // if bimage defined, use its string as an image url for this buttons style (RS)
 						$(btnOpt).css( 'background', 'url('+btn.bimage+') no-repeat center left' );
 						$(btnOpt).css( 'paddingLeft', 20 );
-						
+
 					if (btn.tooltip) // add title if exists (RS)
 						$(btnOpt)[0].title = btn.tooltip;
-						
+
 					if (btn.onpress)
 					{
 						btnOpt.value = btn.onpress;
 					}
 					$(tSelect).append(btnOpt);
-				} 
+				}
 			}
 			$('.tDiv2').append(btnDiv);
-		}		
-	
-		
+		}
+
+
 		$(t).before(g.hDiv);
 		g.hTable.cellPadding = 0;
 		g.hTable.cellSpacing = 0;
@@ -1107,8 +1111,8 @@
 					height: cdheight + hdheight
 				}).mousedown(function (e) {
 					g.dragStart('colresize', e, this);
-				}).dblclick(function(e){ 
-					g.autoResizeColumn(this); 
+				}).dblclick(function(e){
+					g.autoResizeColumn(this);
 				});
 				if ($.browser.msie && $.browser.version < 7.0) {
 					g.fixHeight($(g.gDiv).height());
@@ -1219,7 +1223,7 @@
 				if (p.qtype == '') {
 					p.qtype = sitems[0].name;
 				}
-				$(g.sDiv).append("<div class='sDiv2'>" + p.findtext + 
+				$(g.sDiv).append("<div class='sDiv2'>" + p.findtext +
 						" <input type='text' value='" + p.query +"' size='30' name='q' class='qsbox' /> "+
 						" <select name='qtype'>" + sopt + "</select></div>");
 				//Split into separate selectors because of bug in jQuery 1.3.2

--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -227,10 +227,8 @@
 					this.rePosDrag();
 					this.fixHeight();
 					this.colresize = false;
-					if ($.cookie) {
-						var name = p.colModel[n].name;		// Store the widths in the cookies
-						$.cookie('flexiwidths/'+name, nw);
-					}
+					var name = p.colModel[n].name;		// Store the widths in the cookies
+					$.cookie('flexiwidths/'+name, nw);
 				} else if (this.vresize) {
 					this.vresize = false;
 				} else if (this.colCopy) {
@@ -824,11 +822,9 @@
 				var th = document.createElement('th');
 				$(th).attr('axis', 'col' + i);
 				if( cm ) {	// only use cm if its defined
-					if ($.cookie) {
-						var cookie_width = 'flexiwidths/'+cm.name;		// Re-Store the widths in the cookies
-						if( $.cookie(cookie_width) != undefined ) {
-							cm.width = $.cookie(cookie_width);
-						}
+					var cookie_width = 'flexiwidths/'+cm.name;		// Re-Store the widths in the cookies
+					if( $.cookie(cookie_width) != undefined ) {
+						cm.width = $.cookie(cookie_width);
 					}
 					if( cm.display != undefined ) {
 						th.innerHTML = cm.display;


### PR DESCRIPTION
Flexigrid currently uses an old style serialization for server-side data, which is inconvenient for modern server languages. For example, if you specify `params: [ { name: 'a', value: [ 1, 2, 3 ] } ]`, the pair `a` = `1,2,3` is sent to the server.

This fix automatically uses modern (according to jQuery) serialization if you use an object for the params option. So if you specify `params: { a: [ 1, 2, 3 ] }`, it now posts `a[0]` = `1`, `a[1]` = `2` and `a[2]` = `2`, which server languages like PHP (and most others) will parse into an array.

Since this fix is triggered by a syntax for the params option that previously caused errors, it should be backwards compatible, yet provides modern behaviour for anybody expecting params to be a plain object.

Also, Netbeans fixed some extraneous whitespace issues.
