### PR TITLE
improved efficiency and CMD key support for Mac users

### DIFF
--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -380,7 +380,7 @@
 								// If the content has a <BGCOLOR=nnnnnn> option, decode it.
 								var offs = td.innerHTML.indexOf( '<BGCOLOR=' );
 								if( offs >0 ) {
-									$(td).css('background',  text.substr(offs+7,7) );
+									$(td).css('background',	 text.substr(offs+7,7) );
 								}
 
 								$(td).attr('abbr', $(this).attr('abbr'));
@@ -429,7 +429,7 @@
 							var text = $("cell:eq(" + idx + ")", robj).text();
 							var offs = text.indexOf( '<BGCOLOR=' );
 							if( offs >0 ) {
-								$(td).css('background',  text.substr(offs+7,7) );
+								$(td).css('background',	 text.substr(offs+7,7) );
 							}
 							td.innerHTML = text;
 							$(td).attr('abbr', $(this).attr('abbr'));
@@ -684,50 +684,51 @@
 				};
 			},
 			addRowProp: function () {
-				$('tbody tr', g.bDiv).each(function () {
-					$(this).click(function (e) {
-						var obj = (e.target || e.srcElement);
-						if (obj.href || obj.type) return true;
-						$(this).toggleClass('trSelected');
-						if (p.singleSelect && ! g.multisel ) {
-							$(this).siblings().removeClass('trSelected');
-							$(this).toggleClass('trSelected');
-						}
-					}).mousedown(function (e) {
-						if (e.shiftKey) {
-							$(this).toggleClass('trSelected');
-							g.multisel = true;
-							this.focus();
-							$(g.gDiv).noSelect();
-						}
-						if (e.ctrlKey)
-						{
-							$(this).toggleClass('trSelected');
-							g.multisel = true;
-							this.focus();
-						}
-					}).mouseup(function () {
-						if (g.multisel && ! e.ctrlKey) {
-							g.multisel = false;
-							$(g.gDiv).noSelect(false);
-						}
-					}).dblclick(function () {
-						if (p.onDoubleClick) {
-							p.onDoubleClick(this, g, p);
-						}
-					}).hover(function (e) {
-						if (g.multisel && e.shiftKey) {
-							$(this).toggleClass('trSelected');
-						}
-					}, function () {});
-					if ($.browser.msie && $.browser.version < 7.0) {
-						$(this).hover(function () {
-							$(this).addClass('trOver');
-						}, function () {
-							$(this).removeClass('trOver');
-						});
+				$('tbody tr', g.bDiv).on('click', function (e) {
+					var obj = (e.target || e.srcElement);
+					if (obj.href || obj.type) return true;
+					if (e.ctrlKey || e.metaKey) {
+						// mousedown already took care of this case
+						return;
 					}
-				});
+					$(this).toggleClass('trSelected');
+					console.log("click: toggle, ms=%s", g.multisel);
+					if (p.singleSelect && ! g.multisel) {
+						$(this).siblings().removeClass('trSelected');
+					}
+				}).on('mousedown', function (e) {
+					if (e.shiftKey) {
+						$(this).toggleClass('trSelected');
+						g.multisel = true;
+						this.focus();
+						$(g.gDiv).noSelect();
+					}
+					if (e.ctrlKey || e.metaKey) {
+						$(this).toggleClass('trSelected');
+						g.multisel = true;
+						this.focus();
+					}
+				}).on('mouseup', function (e) {
+					if (g.multisel && ! (e.ctrlKey || e.metaKey)) {
+						g.multisel = false;
+						$(g.gDiv).noSelect(false);
+					}
+				}).on('dblclick', function () {
+					if (p.onDoubleClick) {
+						p.onDoubleClick(this, g, p);
+					}
+				}).hover(function (e) {
+					if (g.multisel && e.shiftKey) {
+						$(this).toggleClass('trSelected');
+					}
+				}, function () {});
+				if ($.browser.msie && $.browser.version < 7.0) {
+					$(this).hover(function () {
+						$(this).addClass('trOver');
+					}, function () {
+						$(this).removeClass('trOver');
+					});
+				}
 			},
 
 			combo_flag: true,
@@ -1433,6 +1434,6 @@
 		}
 	}; //end noSelect
   $.fn.flexSearch = function(p) { // function to search grid
-    return this.each( function() { if (this.grid&&this.p.searchitems) this.grid.doSearch(); });
+	return this.each( function() { if (this.grid&&this.p.searchitems) this.grid.doSearch(); });
   }; //end flexSearch
 })(jQuery);

--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -692,7 +692,6 @@
 						return;
 					}
 					$(this).toggleClass('trSelected');
-					console.log("click: toggle, ms=%s", g.multisel);
 					if (p.singleSelect && ! g.multisel) {
 						$(this).siblings().removeClass('trSelected');
 					}


### PR DESCRIPTION
This contains several changes in a single diff. I hope it's not too confusing. Also - this is my first pull request: I hope I have done it right.

The first is, I improved the efficiency of the addRowProp function. The problem with it, as I saw it, was it was creating new copies of the event handler for each row in the response. That's because it was calling $.each(...) on each row. But that's not necessary as that behavior is part of how jQuery works.

Second, I added support for metaKey so that Mac users can select multiple items by using CMD instead of Control, because on Macs, Control-click means RIGHT click and brings up the menu.

Third, there was a missing 'e' argument to the mouseup handler. That was reported and fixed by another user as well.

Along with that change I improved the behavior of clicking and meta/control clicking. There was a situation where a control-click was toggling an item and then immediately toggling it again, once in the mousedown handler and once in the click handler.
