### PR TITLE
Property float of the object is quoted

### DIFF
--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -154,7 +154,7 @@
 					}
 					$(this.colCopy).css({
 						position: 'absolute',
-						float: 'left',
+						'float': 'left',
 						display: 'none',
 						textAlign: obj.align
 					});

--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -324,6 +324,7 @@
 				this.loading = false;
 				if (!data) {
 					$('.pPageStat', this.pDiv).html(p.errormsg);
+                    if (p.onSuccess) p.onSuccess(this);
 					return false;
 				}
 				if (p.dataType == 'xml') {
@@ -338,6 +339,7 @@
 					p.page = 1;
 					this.buildpager();
 					$('.pPageStat', this.pDiv).html(p.nomsg);
+                    if (p.onSuccess) p.onSuccess(this);
 					return false;
 				}
 				p.pages = Math.ceil(p.total / p.rp);


### PR DESCRIPTION
'float' is a reserved word in EcmaScript 3, thus it must be quoted.  If I remember correctly, this is one of the things that  changed for EcmaScript 5.
IE: If it isn't the script don't pass google closure compiler.
