### PR TITLE
Minor changes to fix position of column drag buttons.

### DIFF
--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -72,6 +72,7 @@
 					top: g.hDiv.offsetTop + 1
 				});
 				var cdpad = this.cdpad;
+				var cdcounter
 				$('div', g.cDrag).hide();
 				$('thead tr:first th:visible', this.hDiv).each(function () {
 					var n = $('thead tr:first th:visible', g.hDiv).index(this);
@@ -82,9 +83,10 @@
 						cdpos = 0;
 					}
 					$('div:eq(' + n + ')', g.cDrag).css({
-						'left': cdpos + 'px'
+						'left': (!($.browser.mozilla) ? cdpos - cdcounter : cdpos) + 'px'
 					}).show();
 					cdleft = cdpos;
+					cdcounter++;
 				});
 			},
 			fixHeight: function (newH) {


### PR DESCRIPTION
This is a minor update to fix the position of column drag buttons in Chrome and IE. It seems that the buttons are not accurately aligned with the columns border in Chrome and IE, but it works perfectly in Firefox.

PS:
Tested on Chrome 23, Firefox 17, and IE 8.
