### PR TITLE
p.width percentage value support

### DIFF
--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -867,8 +867,8 @@
 		g.hTable = document.createElement('table');
 		g.gDiv.className = 'flexigrid';
 		if (p.width != 'auto') {
-			g.gDiv.style.width = p.width + 'px';
-		}
+			g.gDiv.style.width = p.width + isNaN(p.width) ? '' : 'px';
+		} 
 		//add conditional classes
 		if ($.browser.msie) {
 			$(g.gDiv).addClass('ie');


### PR DESCRIPTION
While setting the p.width param's value to a percentage value, IE would
not show the grid.
