### PR TITLE
Demos are currently broken because they're using the latest version of jQuery from the Google CDN

### DIFF
--- a/demo/conflict-test.html
+++ b/demo/conflict-test.html
@@ -4,7 +4,7 @@
 		<meta http-equiv="content-type" content="text/html;charset=UTF-8" />
 		<title>Testing Flexigrid + Prototype</title>
 		<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/prototype/1.7.0.0/prototype.js"></script>
-		<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+		<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 		<script type="text/javascript">jQuery.noConflict();</script>
 		<link rel="stylesheet" type="text/css" href="../css/flexigrid.css" media="all" />
 		<script type="text/javascript" src="../js/flexigrid.js"></script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
 	<link rel="stylesheet" href="style.css" />
 	<link rel="stylesheet" type="text/css" href="../css/flexigrid.pack.css" />
 	<script type="text/javascript"
-		src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+		src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 	<script type="text/javascript" src="../js/flexigrid.pack.js"></script>
 </head>
 <body>

--- a/demo/sample.html
+++ b/demo/sample.html
@@ -4,7 +4,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Flexigrid</title>
 <link rel="stylesheet" type="text/css" href="../css/flexigrid.css">
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 <script type="text/javascript" src="../js/flexigrid.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Demos are broken because jQuery 1.9 does not support the $.browser
object; for now, specify version 1.8.3 for the demos.
