### PR TITLE
Make header stay centered

### DIFF
--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -1004,7 +1004,6 @@
 				$(this).attr('axis', 'col' + ci++);
 			}
 			$(thdiv).css({
-				textAlign: this.align,
 				width: this.width + 'px'
 			});
 			thdiv.innerHTML = this.innerHTML;


### PR DESCRIPTION
Make header divs center-aligned even though the columns are left or
right-aligned.
