### PR TITLE
Prevent click event from firing when dblclick event fires

### DIFF
--- a/js/flexigrid.js
+++ b/js/flexigrid.js
@@ -775,6 +775,7 @@
 			},
 			addRowProp: function () {
 				$('tbody tr', g.bDiv).on('click', function (e) {
+					e.preventDefault();
 					var obj = (e.target || e.srcElement);
 					if (obj.href || obj.type) return true;
 					if (e.ctrlKey || e.metaKey) {


### PR DESCRIPTION
Prevent click event from firing when dblclick event fires
